### PR TITLE
Fix Activation Command for Virtual Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Mercury automates GitHub and Notion interactions, summarizing activity for the p
 
 1. Clone the repository.
 2. Set up a virtual environment and install dependencies:
-   `python -m venv venv source venv/bin/activate pip install -r requirements.txt`
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
 3. Set up the page you want to post to in Notion
 4. Configure your `.env` file based on `.env.example`.
 


### PR DESCRIPTION
I noticed an issue with the activation command for the virtual environment in the documentation.
Currently, it's written as a single line, which causes it to fail.
This update breaks the command into separate lines, making it functional.  
